### PR TITLE
fix(query): improve keyword matching for CJK languages

### DIFF
--- a/tools/query.py
+++ b/tools/query.py
@@ -42,14 +42,28 @@ def find_relevant_pages(question: str, index_content: str) -> list[Path]:
     """Extract linked pages from index that seem relevant to the question."""
     # Pull all [[links]] and markdown links from index
     md_links = re.findall(r'\[([^\]]+)\]\(([^)]+)\)', index_content)
-    # Simple keyword match: check if any word in the title appears in the question
     question_lower = question.lower()
     relevant = []
+    
     for title, href in md_links:
-        if any(word in question_lower for word in title.lower().split() if len(word) > 3):
+        title_lower = title.lower()
+        match = False
+        
+        # 1. English/Space-separated: check words > 3 chars
+        if any(word in question_lower for word in title_lower.split() if len(word) > 3):
+            match = True
+        # 2. Exact substring match for the whole title (useful for short CJK titles, e.g. len=2)
+        elif len(title_lower) >= 2 and title_lower in question_lower:
+            match = True
+        # 3. CJK chunks: find contiguous non-ASCII characters (len >= 2) and check if in question
+        elif any(chunk in question_lower for chunk in re.findall(r'[^\x00-\x7F]{2,}', title_lower)):
+            match = True
+            
+        if match:
             p = WIKI_DIR / href
-            if p.exists():
+            if p.exists() and p not in relevant:
                 relevant.append(p)
+                
     # Always include overview
     overview = WIKI_DIR / "overview.md"
     if overview.exists() and overview not in relevant:


### PR DESCRIPTION
## Description
The current implementation in `tools/query.py` uses `title.lower().split()` and filters for `len(word) > 3` to perform keyword matching. This approach completely breaks for CJK (Chinese, Japanese, Korean) languages because:
1. CJK languages do not use spaces for word separation.
2. Words and sentences are composed of Unicode characters where a length of 1 or 2 is semantically significant and commonplace.

As a result, CJK users currently always fall back to the Claude Haiku API to find relevant pages, bypassing the local keyword match.

## Changes
This PR enhances `find_relevant_pages()` to support both space-separated and non-space-separated languages:
1. **Preserved English Support**: Original token splitting > 3 is kept intact.
2. **Short Title Exact Match**: Checks if the entire title (if length >= 2) exists as a substring in the question (resolves issues with short 2-character names).
3. **CJK Chunks**: Extracts contiguous non-ASCII characters (e.g. Chinese characters) of length >= 2 and checks if those chunks appear in the question.

This ensures zero regressions for English users while making the CLI instantly responsive and usable for global users.
