### PR TITLE
feat(ingest): support batch processing of multiple files or directories

### DIFF
--- a/tools/ingest.py
+++ b/tools/ingest.py
@@ -190,6 +190,40 @@ Return ONLY a valid JSON object with these fields (no markdown fences, no prose 
 
 if __name__ == "__main__":
     if len(sys.argv) < 2:
-        print("Usage: python tools/ingest.py <path-to-source>")
+        print("Usage: python tools/ingest.py <path-to-source> [path2 ...] [dir1 ...]")
         sys.exit(1)
-    ingest(sys.argv[1])
+        
+    paths_to_process = []
+    for arg in sys.argv[1:]:
+        p = Path(arg)
+        if p.is_file() and p.suffix == ".md":
+            paths_to_process.append(p)
+        elif p.is_dir():
+            for f in p.rglob("*.md"):
+                if f.is_file():
+                    paths_to_process.append(f)
+        else:
+            import glob
+            for f in glob.glob(arg, recursive=True):
+                g_p = Path(f)
+                if g_p.is_file() and g_p.suffix == ".md":
+                    paths_to_process.append(g_p)
+                    
+    # Deduplicate while preserving order
+    unique_paths = []
+    seen = set()
+    for p in paths_to_process:
+        abs_p = p.resolve()
+        if abs_p not in seen:
+            seen.add(abs_p)
+            unique_paths.append(p)
+
+    if not unique_paths:
+        print("Error: no markdown files found to ingest.")
+        sys.exit(1)
+        
+    if len(unique_paths) > 1:
+        print(f"Batch mode: found {len(unique_paths)} files to ingest.")
+        
+    for p in unique_paths:
+        ingest(str(p))


### PR DESCRIPTION
## Description
Currently, `tools/ingest.py` only accepts a single file path. When a user has an existing personal knowledge base (e.g., an Obsidian vault) with hundreds of journal entries or notes, writing manual shell loops to ingest them is tedious and error-prone.

## Changes
This PR updates `tools/ingest.py` to support multiple file paths, directory recursion, and glob patterns in a single command. 

Usage examples that now work:
```bash
python tools/ingest.py raw/diary/2026-04-11.md raw/diary/2026-04-12.md
python tools/ingest.py raw/diary/2026/
python tools/ingest.py "raw/deep-dives/*.md"
