### PR TITLE
docs: add domain-specific templates and Obsidian integration guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,6 +98,48 @@ source_file: raw/...
 - Contradicts [[OtherPage]] on: ...
 ```
 
+### Domain-Specific Templates
+
+If the source falls into a specific domain (e.g., personal diary, meeting notes), the agent should use a specialized template instead of the default generic one above:
+
+#### Diary / Journal Template
+```markdown
+---
+title: "YYYY-MM-DD Diary"
+type: source
+tags: [diary]
+date: YYYY-MM-DD
+---
+## Event Summary
+...
+## Key Decisions
+...
+## Energy & Mood
+...
+## Connections
+...
+## Shifts & Contradictions
+...
+```
+
+#### Meeting Notes Template
+```markdown
+---
+title: "Meeting Title"
+type: source
+tags: [meeting]
+date: YYYY-MM-DD
+---
+## Goal
+...
+## Key Discussions
+...
+## Decisions Made
+...
+## Action Items
+...
+```
+
 ---
 
 ## Query Workflow

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,48 @@ source_file: raw/...
 - Contradicts [[OtherPage]] on: ...
 ```
 
+### Domain-Specific Templates
+
+If the source falls into a specific domain (e.g., personal diary, meeting notes), the agent should use a specialized template instead of the default generic one above:
+
+#### Diary / Journal Template
+```markdown
+---
+title: "YYYY-MM-DD Diary"
+type: source
+tags: [diary]
+date: YYYY-MM-DD
+---
+## Event Summary
+...
+## Key Decisions
+...
+## Energy & Mood
+...
+## Connections
+...
+## Shifts & Contradictions
+...
+```
+
+#### Meeting Notes Template
+```markdown
+---
+title: "Meeting Title"
+type: source
+tags: [meeting]
+date: YYYY-MM-DD
+---
+## Goal
+...
+## Key Discussions
+...
+## Decisions Made
+...
+## Action Items
+...
+```
+
 ---
 
 ## Query Workflow

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -94,6 +94,48 @@ source_file: raw/...
 - Contradicts [[OtherPage]] on: ...
 ```
 
+### Domain-Specific Templates
+
+If the source falls into a specific domain (e.g., personal diary, meeting notes), the agent should use a specialized template instead of the default generic one above:
+
+#### Diary / Journal Template
+```markdown
+---
+title: "YYYY-MM-DD Diary"
+type: source
+tags: [diary]
+date: YYYY-MM-DD
+---
+## Event Summary
+...
+## Key Decisions
+...
+## Energy & Mood
+...
+## Connections
+...
+## Shifts & Contradictions
+...
+```
+
+#### Meeting Notes Template
+```markdown
+---
+title: "Meeting Title"
+type: source
+tags: [meeting]
+date: YYYY-MM-DD
+---
+## Goal
+...
+## Key Discussions
+...
+## Decisions Made
+...
+## Action Items
+...
+```
+
 ---
 
 ## Query Workflow

--- a/README.md
+++ b/README.md
@@ -206,10 +206,27 @@ The schema file tells the agent how to maintain the wiki — page formats, inges
 | Contradictions surface at query time (maybe) | Flagged at ingest time |
 | No accumulation | Every source makes the wiki richer |
 
+## Obsidian Integration
+
+The wiki is designed to be browsed seamlessly in [Obsidian](https://obsidian.md). Since the agent maintains consistent `[[wikilinks]]`, you get a naturally growing knowledge graph in your vault.
+
+### Vault Symlink Pattern
+If you want to keep the LLM Wiki Agent repository separate from your main personal vault, use symlinks:
+1. Keep your working agent repository at e.g., `~/llm-wiki-agent`
+2. Create a symlink from your main Obsidian vault:
+   ```bash
+   ln -sfn ~/llm-wiki-agent/wiki ~/your-obsidian-vault/wiki
+   ```
+3. Use the [Obsidian Web Clipper](https://obsidian.md/clipper) or write directly to `raw/` in the agent repo to queue items for ingestion.
+
+> **Note:** If you ever move your local repo directory, remember to update the symlink, otherwise the `wiki/` directory will appear missing in Obsidian.
+
+### Recommended .obsidian Config
+- **Graph View:** Filter out `index.md` and `log.md` (e.g. `-file:index.md -file:log.md`) to avoid them becoming gravity wells in your Obsidian graph.
+- **Dataview:** Use the community plugin [Dataview](https://blacksmithgu.github.io/obsidian-dataview/) to query the YAML frontmatter the agent automatically injects (e.g., `type: source`, `tags: [diary]`).
+
 ## Tips
 
-- Use [Obsidian](https://obsidian.md) to browse the wiki — follow links, check graph view, use Dataview for frontmatter queries
-- Use [Obsidian Web Clipper](https://obsidian.md/clipper) to clip web articles directly to `raw/`
 - File good query answers back with `--save` — your explorations compound just like ingested sources
 - The wiki is a git repo — version history for free
 - Standalone Python scripts in `tools/` work without a coding agent (require `ANTHROPIC_API_KEY`)


### PR DESCRIPTION
## Description
As users scale their personal LLM Wiki, two patterns quickly emerge:
1. Different source types (e.g. daily journals, meeting notes) require different extraction paradigms than standard academic papers.
2. Users want to deeply integrate the `wiki/` directory with their existing Obsidian vaults via symlinks.

## Changes
- **Schemas**: Updated `CLAUDE.md`, `GEMINI.md`, and `AGENTS.md` to introduce the concept of `Domain-Specific Templates`. The agent is now explicitly instructed to use structured templates for specific domains (like Diary/Journal and Meeting Notes).
- **README**: Added a dedicated `## Obsidian Integration` section documenting proper symlinking procedures and recommended `.obsidian` graph view filters (excluding `index.md` to prevent gravity wells).
