### PR TITLE
feat(lint): graph-aware checks — hub stubs, fragile bridges, isolated communities (Phase 2 of #25)

### DIFF
--- a/tools/lint.py
+++ b/tools/lint.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+from __future__ import annotations
+
 """
 Lint the LLM Wiki for health issues.
 
@@ -16,7 +18,9 @@ Checks:
 
 import re
 import sys
+import json
 import argparse
+import statistics
 from pathlib import Path
 from collections import defaultdict
 from datetime import date
@@ -25,6 +29,8 @@ import os
 
 REPO_ROOT = Path(__file__).parent.parent
 WIKI_DIR = REPO_ROOT / "wiki"
+GRAPH_DIR = REPO_ROOT / "graph"
+GRAPH_JSON = GRAPH_DIR / "graph.json"
 LOG_FILE = WIKI_DIR / "log.md"
 SCHEMA_FILE = REPO_ROOT / "CLAUDE.md"
 
@@ -101,6 +107,131 @@ def find_missing_entities(pages: list[Path]) -> list[str]:
     return [name for name, count in mention_counts.items() if count >= 3]
 
 
+# ── Graph-aware checks ──────────────────────────────────────────────
+
+def load_graph_data() -> dict | None:
+    """Load graph.json if it exists. Returns None if missing (graceful degradation)."""
+    if not GRAPH_JSON.exists():
+        return None
+    try:
+        return json.loads(GRAPH_JSON.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, IOError):
+        print("  [warn] graph.json is corrupted — skipping graph-aware checks")
+        return None
+
+
+def _build_degree_map(graph_data: dict) -> dict[str, int]:
+    """Build node_id -> degree mapping from graph edges."""
+    degrees: dict[str, int] = {}
+    for node in graph_data.get("nodes", []):
+        degrees[node["id"]] = 0
+    for edge in graph_data.get("edges", []):
+        degrees[edge["from"]] = degrees.get(edge["from"], 0) + 1
+        degrees[edge["to"]] = degrees.get(edge["to"], 0) + 1
+    return degrees
+
+
+def _build_community_map(graph_data: dict) -> dict[str, int]:
+    """Build node_id -> community_id mapping from graph nodes."""
+    return {
+        node["id"]: node.get("group", -1)
+        for node in graph_data.get("nodes", [])
+    }
+
+
+def check_hub_stubs(graph_data: dict, pages: list[Path], min_content_chars: int = 500) -> list[dict]:
+    """Find god nodes (degree > μ+2σ) with suspiciously short content."""
+    degrees = _build_degree_map(graph_data)
+    deg_values = list(degrees.values())
+    if len(deg_values) < 2:
+        return []
+
+    mean_deg = statistics.mean(deg_values)
+    std_deg = statistics.stdev(deg_values)
+    threshold = mean_deg + 2 * std_deg
+
+    # Map node_id -> page path
+    node_to_path: dict[str, Path] = {}
+    for p in pages:
+        nid = p.relative_to(WIKI_DIR).as_posix().replace(".md", "")
+        node_to_path[nid] = p
+
+    results = []
+    for node_id, deg in degrees.items():
+        if deg <= threshold:
+            continue
+        path = node_to_path.get(node_id)
+        if not path:
+            continue
+        content_len = len(read_file(path))
+        if content_len < min_content_chars:
+            results.append({
+                "node_id": node_id,
+                "degree": deg,
+                "content_len": content_len,
+                "path": str(path.relative_to(REPO_ROOT)),
+            })
+    return sorted(results, key=lambda x: x["degree"], reverse=True)
+
+
+def check_fragile_bridges(graph_data: dict) -> list[dict]:
+    """Find community pairs connected by only 1 edge."""
+    comm_map = _build_community_map(graph_data)
+    cross_comm: dict[tuple[int, int], list[dict]] = {}
+
+    for edge in graph_data.get("edges", []):
+        ca = comm_map.get(edge["from"], -1)
+        cb = comm_map.get(edge["to"], -1)
+        if ca < 0 or cb < 0 or ca == cb:
+            continue
+        key = (min(ca, cb), max(ca, cb))
+        cross_comm.setdefault(key, []).append(edge)
+
+    return [
+        {
+            "comm_a": pair[0],
+            "comm_b": pair[1],
+            "bridge_from": edges[0]["from"],
+            "bridge_to": edges[0]["to"],
+        }
+        for pair, edges in sorted(cross_comm.items())
+        if len(edges) == 1
+    ]
+
+
+def check_isolated_communities(graph_data: dict) -> list[dict]:
+    """Find communities with zero external edges (knowledge silos)."""
+    comm_map = _build_community_map(graph_data)
+
+    # Build community -> members
+    comm_members: dict[int, list[str]] = {}
+    for node_id, comm_id in comm_map.items():
+        if comm_id < 0:
+            continue
+        comm_members.setdefault(comm_id, []).append(node_id)
+
+    # Track which communities have external edges
+    has_external = set()
+    for edge in graph_data.get("edges", []):
+        ca = comm_map.get(edge["from"], -1)
+        cb = comm_map.get(edge["to"], -1)
+        if ca >= 0 and cb >= 0 and ca != cb:
+            has_external.add(ca)
+            has_external.add(cb)
+
+    results = []
+    for comm_id, members in sorted(comm_members.items()):
+        if len(members) < 2:  # skip single-node "communities"
+            continue
+        if comm_id not in has_external:
+            results.append({
+                "community_id": comm_id,
+                "node_count": len(members),
+                "members": members[:10],  # cap display
+            })
+    return results
+
+
 def run_lint():
     pages = all_wiki_pages()
     today = date.today().isoformat()
@@ -119,6 +250,25 @@ def run_lint():
     print(f"  orphans: {len(orphans)}")
     print(f"  broken links: {len(broken)}")
     print(f"  missing entity pages: {len(missing_entities)}")
+
+    # ── Graph-aware checks ──
+    graph_data = load_graph_data()
+    hub_stubs: list[dict] = []
+    fragile_bridges: list[dict] = []
+    isolated_comms: list[dict] = []
+
+    if graph_data and graph_data.get("nodes") and graph_data.get("edges"):
+        print("  running graph-aware checks...")
+        hub_stubs = check_hub_stubs(graph_data, pages)
+        fragile_bridges = check_fragile_bridges(graph_data)
+        isolated_comms = check_isolated_communities(graph_data)
+        print(f"    hub stubs: {len(hub_stubs)}")
+        print(f"    fragile bridges: {len(fragile_bridges)}")
+        print(f"    isolated communities: {len(isolated_comms)}")
+    elif graph_data:
+        print("  [skip] graph.json has no data — skipping graph-aware checks")
+    else:
+        print("  [skip] no graph.json — run build_graph.py first for graph-aware checks")
 
     # Build context for semantic checks (contradictions, gaps)
     # Use a sample of pages to stay within context limits
@@ -179,6 +329,59 @@ Be specific — name the exact pages and claims involved.
 
     if not orphans and not broken and not missing_entities:
         report_lines.append("No structural issues found.")
+        report_lines.append("")
+
+    # ── Graph-Aware Issues section ──
+    report_lines.append("## Graph-Aware Issues")
+    report_lines.append("")
+
+    if not graph_data:
+        report_lines.append("> [!tip]")
+        report_lines.append("> Graph-aware checks were skipped. Run `python tools/build_graph.py` first, then re-run lint.")
+        report_lines.append("")
+    elif not graph_data.get("nodes") or not graph_data.get("edges"):
+        report_lines.append("> [!tip]")
+        report_lines.append("> Graph data is empty. Ingest sources and run `python tools/build_graph.py` to populate.")
+        report_lines.append("")
+    else:
+        # Hub stubs
+        report_lines.append(f"### Hub Pages with Insufficient Content ({len(hub_stubs)} pages)")
+        if hub_stubs:
+            report_lines.append("These hub nodes carry disproportionate connectivity but have thin content:")
+            report_lines.append("")
+            report_lines.append("| Page | Degree | Content Length | Status |")
+            report_lines.append("|---|---|---|---|")
+            for hs in hub_stubs:
+                status = "🔴 stub" if hs["content_len"] < 250 else "🟡 thin"
+                report_lines.append(f"| `{hs['path']}` | {hs['degree']} | {hs['content_len']} chars | {status} |")
+        else:
+            report_lines.append("No hub stubs detected — all high-degree nodes have sufficient content.")
+        report_lines.append("")
+
+        # Fragile bridges
+        report_lines.append(f"### Fragile Bridges ({len(fragile_bridges)} community pairs)")
+        if fragile_bridges:
+            report_lines.append("These community connections rely on a single edge — one broken link isolates them:")
+            for fb in fragile_bridges:
+                report_lines.append(f"- Community {fb['comm_a']} ↔ Community {fb['comm_b']} via `{fb['bridge_from']}` → `{fb['bridge_to']}`")
+        else:
+            report_lines.append("No fragile bridges — all community connections have redundant links.")
+        report_lines.append("")
+
+        # Isolated communities
+        report_lines.append(f"### Isolated Communities ({len(isolated_comms)} communities)")
+        if isolated_comms:
+            report_lines.append("These communities have zero external connections — knowledge silos:")
+            report_lines.append("")
+            report_lines.append("| Community | Nodes | Members |")
+            report_lines.append("|---|---|---|")
+            for ic in isolated_comms:
+                members_str = ", ".join(ic["members"][:5])
+                if ic["node_count"] > 5:
+                    members_str += ", …"
+                report_lines.append(f"| {ic['community_id']} | {ic['node_count']} | {members_str} |")
+        else:
+            report_lines.append("No isolated communities — all clusters have external connections.")
         report_lines.append("")
 
     report_lines.append("---")


### PR DESCRIPTION
## Summary
Implements Phase 2 of #25: integrates graph structural insights into the existing lint workflow.

## What's included
- `load_graph_data()` — loads graph.json with graceful degradation
- `check_hub_stubs()` — god nodes (degree > μ+2σ) with < 500 chars content
- `check_fragile_bridges()` — community pairs connected by single edge
- `check_isolated_communities()` — communities with zero external edges
- Report output in `lint-report.md` under new 'Graph-Aware Issues' section

## Design decisions
- **Consumer pattern**: lint.py only reads graph.json, never writes. build_graph.py is the sole producer.
- **Graceful degradation**: all graph checks silently skip if graph.json is missing or empty.
- **No new dependencies**: uses stdlib json + statistics.

## What's NOT included
- Phase 3: Auto-linking

## Testing
```bash
# Without graph (graceful degradation)
rm -f graph/graph.json && python tools/lint.py

# With graph
python tools/build_graph.py --no-infer && python tools/lint.py --save
grep 'Graph-Aware' wiki/lint-report.md
```

Ref: #25, PR #26 (Phase 1)