### PR TITLE
docs: clarify query save UX — answer shown before save decision

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,8 @@ Track a company, market, or technology over time.
 
 /wiki-query "How do OpenAI and Anthropic differ on safety approach?"
 /wiki-query "Which companies announced multimodal models in the last 6 months?"
-/wiki-query "Competitive landscape summary as of today" --save
+/wiki-query "Competitive landscape summary as of today"
+# → agent shows the answer, then asks if you want to save it as a synthesis page
 ```
 
 ## The Graph
@@ -227,7 +228,7 @@ If you want to keep the LLM Wiki Agent repository separate from your main person
 
 ## Tips
 
-- File good query answers back with `--save` — your explorations compound just like ingested sources
+- Query answers are shown first — the agent then asks if you want to file them as synthesis pages. Your explorations compound just like ingested sources
 - The wiki is a git repo — version history for free
 - Standalone Python scripts in `tools/` work without a coding agent (require `ANTHROPIC_API_KEY`)
 


### PR DESCRIPTION
## What

Clarifies the `--save` flag documentation in the Competitive Analysis example and Tips section.

## Why

Issue #28 correctly identified a UX ambiguity: the README example `/wiki-query "..." --save` implies the user must decide to save **before** seeing the query answer.

In practice, the agent schema files (CLAUDE.md, GEMINI.md) already implement a post-hoc workflow:
1. User runs `/wiki-query`
2. Agent shows the synthesized answer
3. Agent asks if the user wants to file it as a synthesis page

The README didn't reflect this — it looked like a pre-commit decision.

## Changes

- Removed `--save` from the Competitive Analysis code example
- Added inline comment showing the actual flow (answer first, then offer to save)
- Updated Tips bullet to describe the post-hoc confirmation workflow

Closes #28