### PR TITLE
Add /wiki-health command

### DIFF
--- a/.claude/commands/wiki-health.md
+++ b/.claude/commands/wiki-health.md
@@ -1,13 +1,13 @@
-Check the wiki for structural problems and fix them:
+Check the wiki for structural problems and report findings. Do not auto-fix.
 
-1. **Empty/stub files**: Find any files under 10 lines in wiki/sources/, wiki/entities/, wiki/concepts/. List them. If the source material exists elsewhere in the wiki (referenced by other pages), reconstruct the page from those references. If not reconstructable, flag for manual re-ingest.
+1. **Empty/stub files**: Find any files under 10 lines in wiki/sources/, wiki/entities/, wiki/concepts/. List them with line counts.
 
-2. **Missing entity pages**: Scan all wiki pages for [[wikilinks]] that point to non-existent files. For each broken link, create the missing entity or concept page using context from the pages that reference it.
+2. **Broken wikilinks**: Scan all wiki pages for [[wikilinks]] that point to non-existent files. List each broken link and the page it appears in.
 
-3. **Orphaned pages**: Find any wiki pages with zero incoming links from other pages. Flag them — they may need cross-references added.
+3. **Orphaned pages**: Find wiki pages with zero incoming links from other pages. List them.
 
-4. **Index sync**: Verify wiki/index.md lists every page in wiki/sources/, wiki/entities/, wiki/concepts/. Add any missing entries. Remove any entries pointing to non-existent files.
+4. **Index sync**: Check wiki/index.md against actual files. Report pages missing from index and index entries pointing to non-existent files.
 
-5. **Log sync**: Verify wiki/log.md has entries for all ingested sources. Add missing entries with [auto-recovered] tag.
+5. **Log sync**: Check wiki/log.md against wiki/sources/. Report any source pages with no corresponding log entry. Tag findings as [missing-log-entry].
 
-6. **Report**: Summarize what was broken and what was fixed. Do not ask for permission — fix everything automatically and report after.
+6. **Report**: Print a structured summary of all findings, grouped by category, with file paths. Do not create, modify, or delete any files.

--- a/.claude/commands/wiki-health.md
+++ b/.claude/commands/wiki-health.md
@@ -1,0 +1,13 @@
+Check the wiki for structural problems and fix them:
+
+1. **Empty/stub files**: Find any files under 10 lines in wiki/sources/, wiki/entities/, wiki/concepts/. List them. If the source material exists elsewhere in the wiki (referenced by other pages), reconstruct the page from those references. If not reconstructable, flag for manual re-ingest.
+
+2. **Missing entity pages**: Scan all wiki pages for [[wikilinks]] that point to non-existent files. For each broken link, create the missing entity or concept page using context from the pages that reference it.
+
+3. **Orphaned pages**: Find any wiki pages with zero incoming links from other pages. Flag them — they may need cross-references added.
+
+4. **Index sync**: Verify wiki/index.md lists every page in wiki/sources/, wiki/entities/, wiki/concepts/. Add any missing entries. Remove any entries pointing to non-existent files.
+
+5. **Log sync**: Verify wiki/log.md has entries for all ingested sources. Add missing entries with [auto-recovered] tag.
+
+6. **Report**: Summarize what was broken and what was fixed. Do not ask for permission — fix everything automatically and report after.


### PR DESCRIPTION
Adds a slash command that checks for empty files, broken wikilinks, orphaned pages, and index/log desync. Designed to run after rate-limit interruptions.