### PR TITLE
feat(graph+lint): phantom hub detection and link density budget (Phase 2.5 of #25)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,7 +169,13 @@ Check for:
 - **Contradictions** — claims that conflict across pages
 - **Stale summaries** — pages not updated after newer sources
 - **Missing entity pages** — entities mentioned in 3+ pages but lacking their own page
+- **Sparse pages** — pages with fewer than 2 outbound `[[wikilinks]]` (link density budget)
 - **Data gaps** — questions the wiki can't answer; suggest new sources
+
+Graph-aware checks (require `graph.json` from `build graph`):
+- **Hub stubs** — god nodes (degree > μ+2σ) with thin content (< 500 chars)
+- **Fragile bridges** — community pairs connected by only 1 edge
+- **Isolated communities** — clusters with zero external connections
 
 Output a lint report and ask if the user wants it saved to `wiki/lint-report.md`.
 
@@ -250,4 +256,37 @@ If Python/deps unavailable, build manually:
 
 `## [YYYY-MM-DD] <operation> | <title>`
 
-Operations: `ingest`, `query`, `health`, `lint`, `graph`
+Operations: `ingest`, `query`, `health`, `lint`, `graph`, `report`
+
+---
+
+## Graph Health Report
+
+Triggered by: *"graph report"* or `python tools/build_graph.py --report`
+
+The `--report` flag generates a structured graph health report covering:
+- **Health summary** — edges/node ratio, orphan %, community count, link density
+- **Orphan nodes** — pages with zero graph connections
+- **God nodes** — hub pages with degree > μ+2σ (disproportionate connectivity)
+- **Fragile bridges** — community pairs connected by only 1 edge
+- **Phantom hubs** — `[[wikilinks]]` referenced by 2+ existing pages but pointing to non-existent pages (page creation signals)
+
+Use `--save` to write the report to `graph/graph-report.md`.
+
+---
+
+## Phase 3 Design Constraints (Auto-Linking — Open)
+
+Phase 3 proposes automatic `[[wikilink]]` insertion based on graph analysis. The following hard rules apply:
+
+### Promotion Gate: `draft → stable`
+- Auto-linked edges start as `DRAFT` (visible in graph, not written to page body)
+- A dedicated `promote` pass validates source grounding + consistency
+- Only edges that pass get materialized as `[[wikilinks]]` in the page
+- **Link density budget**: a page must have ≥2 outbound wikilinks before promotion
+
+### Hard Rules
+| ID | Rule | Rationale |
+|---|---|---|
+| HG-WA-01 | Graph layer MUST NOT auto-create pages from broken links — report only | LLM ingest produces hallucinated wikilinks; auto-creating amplifies noise |
+| HG-WA-02 | New slash commands MUST NOT duplicate existing command coverage | Prevents user confusion; merge into existing commands instead |

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -158,7 +158,9 @@ Triggered by: *"query: <question>"*
 
 Triggered by: *"lint"*
 
-Check for: orphan pages, broken links, contradictions, stale content, missing entity pages, data gaps.
+Check for: orphan pages, broken links, contradictions, stale content, missing entity pages, sparse pages (< 2 outbound links), data gaps.
+
+Graph-aware checks (require `graph.json`): hub stubs, fragile bridges, isolated communities.
 
 ---
 
@@ -207,3 +209,22 @@ Try `python tools/build_graph.py --open` first. If unavailable, build graph.json
 ## Log Format
 
 `## [YYYY-MM-DD] <operation> | <title>`
+
+Operations: `ingest`, `query`, `lint`, `graph`, `report`
+
+---
+
+## Graph Health Report
+
+Triggered by: *"graph report"* or `python tools/build_graph.py --report`
+
+Covers: health summary, orphan nodes, god nodes, fragile bridges, phantom hubs. Use `--save` to persist.
+
+---
+
+## Phase 3 Design Constraints (Auto-Linking — Open)
+
+- Auto-linked edges start as `DRAFT`, require promotion gate validation
+- Link density budget: ≥2 outbound wikilinks before promotion
+- HG-WA-01: Graph layer MUST NOT auto-create pages from broken links
+- HG-WA-02: New commands MUST NOT duplicate existing command coverage

--- a/tools/build_graph.py
+++ b/tools/build_graph.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+from __future__ import annotations
+
 """
 Build the knowledge graph from the wiki.
 
@@ -408,11 +410,44 @@ def detect_communities(nodes: list[dict], edges: list[dict]) -> dict[str, int]:
         return {}
 
 
-def generate_report(nodes: list[dict], edges: list[dict], communities: dict[str, int]) -> str:
+def find_phantom_hubs(pages: list[Path], min_refs: int = 2) -> list[dict]:
+    """Find wikilinks referenced by multiple pages but pointing to non-existent pages.
+
+    These are strong signals for pages that should be created next.
+    Returns list of dicts with 'name', 'ref_count', and 'referenced_by' keys,
+    sorted by ref_count descending.
+    """
+    existing_stems = {p.stem.lower() for p in pages}
+    # Count how many distinct pages reference each missing target
+    refs: dict[str, set[str]] = {}  # target_name -> set of source page_ids
+    for p in pages:
+        content = read_file(p)
+        links = extract_wikilinks(content)
+        src = page_id(p)
+        for link in links:
+            if link.lower() not in existing_stems:
+                refs.setdefault(link, set()).add(src)
+
+    phantoms = [
+        {
+            "name": name,
+            "ref_count": len(sources),
+            "referenced_by": sorted(sources),
+        }
+        for name, sources in refs.items()
+        if len(sources) >= min_refs
+    ]
+    phantoms.sort(key=lambda x: x["ref_count"], reverse=True)
+    return phantoms
+
+
+def generate_report(nodes: list[dict], edges: list[dict], communities: dict[str, int],
+                    pages: list[Path] | None = None) -> str:
     """Generate a structured graph health report.
 
     Analyzes the graph for orphan nodes, hub pages (god nodes),
-    fragile inter-community bridges, and overall connectivity health.
+    fragile inter-community bridges, phantom hubs (referenced but
+    non-existent pages), and overall connectivity health.
     """
     today = date.today().isoformat()
     n_nodes = len(nodes)
@@ -543,6 +578,26 @@ def generate_report(nodes: list[dict], edges: list[dict], communities: dict[str,
     lines.append("")
 
     # Suggested actions
+    # Phantom hubs section
+    phantoms = find_phantom_hubs(pages) if pages else []
+    lines.append("## 🟠 Phantom Hubs (referenced but non-existent pages)")
+    if phantoms:
+        lines.append("These pages are referenced by 2+ existing pages but don't exist yet.")
+        lines.append("They represent strong page creation signals — prioritize by reference count:")
+        lines.append("")
+        lines.append("| Page Name | References | Referenced By |")
+        lines.append("|---|---|---|")
+        for ph in phantoms:
+            refs_preview = ", ".join(ph["referenced_by"][:3])
+            if len(ph["referenced_by"]) > 3:
+                refs_preview += ", …"
+            lines.append(f"| `[[{ph['name']}]]` | {ph['ref_count']} | {refs_preview} |")
+    elif pages:
+        lines.append("No phantom hubs — all referenced pages exist.")
+    else:
+        lines.append("Phantom hub detection skipped (no page data available).")
+    lines.append("")
+
     lines.append("## Suggested Actions")
     actions = []
     if orphans:
@@ -551,6 +606,8 @@ def generate_report(nodes: list[dict], edges: list[dict], communities: dict[str,
         actions.append(f"{len(actions)+1}. Review god nodes for stub content vs. genuine hubs")
     if fragile_bridges:
         actions.append(f"{len(actions)+1}. Strengthen fragile bridges with cross-references")
+    if phantoms:
+        actions.append(f"{len(actions)+1}. Create pages for top phantom hubs (start with `[[{phantoms[0]['name']}]]` — {phantoms[0]['ref_count']} references)")
     if not actions:
         actions.append("1. Graph is in good shape — maintain current linking practices")
     lines.extend(actions)
@@ -1219,7 +1276,7 @@ def build_graph(infer: bool = True, open_browser: bool = False, clean: bool = Fa
         if not HAS_NETWORKX:
             print("Warning: networkx not installed. Cannot generate report.")
         else:
-            report_text = generate_report(nodes, edges, communities)
+            report_text = generate_report(nodes, edges, communities, pages=pages)
             print("\n" + report_text)
             if save:
                 report_path = GRAPH_DIR / "graph-report.md"

--- a/tools/lint.py
+++ b/tools/lint.py
@@ -107,6 +107,30 @@ def find_missing_entities(pages: list[Path]) -> list[str]:
     return [name for name, count in mention_counts.items() if count >= 3]
 
 
+def check_link_density(pages: list[Path], min_outbound: int = 2) -> list[dict]:
+    """Find pages with fewer than min_outbound outgoing wikilinks.
+
+    Pages without enough outgoing connections contribute to wiki fragmentation.
+    Excludes overview.md (which is a synthesis page with different linking patterns).
+    """
+    results = []
+    for p in pages:
+        if p.name == "overview.md":
+            continue
+        content = read_file(p)
+        links = extract_wikilinks(content)
+        # Deduplicate links per page
+        unique_links = set(link.lower() for link in links)
+        if len(unique_links) < min_outbound:
+            results.append({
+                "path": str(p.relative_to(REPO_ROOT)),
+                "outbound_links": len(unique_links),
+                "links": sorted(unique_links),
+            })
+    results.sort(key=lambda x: x["outbound_links"])
+    return results
+
+
 # ── Graph-aware checks ──────────────────────────────────────────────
 
 def load_graph_data() -> dict | None:
@@ -251,6 +275,10 @@ def run_lint():
     print(f"  broken links: {len(broken)}")
     print(f"  missing entity pages: {len(missing_entities)}")
 
+    # Link density check
+    sparse_pages = check_link_density(pages)
+    print(f"  sparse pages (< 2 outbound links): {len(sparse_pages)}")
+
     # ── Graph-aware checks ──
     graph_data = load_graph_data()
     hub_stubs: list[dict] = []
@@ -327,8 +355,19 @@ Be specific — name the exact pages and claims involved.
             report_lines.append(f"- `[[{name}]]`")
         report_lines.append("")
 
-    if not orphans and not broken and not missing_entities:
+    if not orphans and not broken and not missing_entities and not sparse_pages:
         report_lines.append("No structural issues found.")
+        report_lines.append("")
+
+    if sparse_pages:
+        report_lines.append(f"### Sparse Pages — Low Outbound Link Density ({len(sparse_pages)} pages)")
+        report_lines.append("These pages have fewer than 2 outbound wikilinks. Add connections to prevent orphan accumulation:")
+        report_lines.append("")
+        report_lines.append("| Page | Outbound Links | Existing Links |")
+        report_lines.append("|---|---|---|")
+        for sp in sparse_pages:
+            existing = ", ".join(f"`[[{l}]]`" for l in sp["links"]) if sp["links"] else "—"
+            report_lines.append(f"| `{sp['path']}` | {sp['outbound_links']} | {existing} |")
         report_lines.append("")
 
     # ── Graph-Aware Issues section ──


### PR DESCRIPTION
## Summary

Implements two community-requested features from [#25 discussion](https://github.com/SamurAIGPT/llm-wiki-agent/issues/25#issuecomment-4274291765) (@xp54320308):

### 1. Phantom Hub Detection (`build_graph.py`)

**What**: Detects `[[wikilinks]]` referenced by 2+ existing pages but pointing to non-existent pages — "phantom hubs."

**Why**: These represent strong signals for which pages to create next. At scale (620+ nodes), manually identifying forward-reference gaps is impractical. The graph already has this information — it just wasn't surfaced.

**Where**: New `find_phantom_hubs()` function + `🟠 Phantom Hubs` section in `--report` output.

Example output:
```
## 🟠 Phantom Hubs (referenced but non-existent pages)
| Page Name | References | Referenced By |
|---|---|---|
| `[[langchain]]` | 4 | sources/paper-a, concepts/RAG, ... |
| `[[wan2-video-models]]` | 2 | sources/paper-b, entities/PersonX |
```

### 2. Link Density Budget (`lint.py`)

**What**: Flags pages with fewer than 2 outbound wikilinks as "sparse pages."

**Why**: A minimum outbound link budget prevents orphan accumulation at the source. This is a precursor to the `draft → stable` promotion gate discussed in #25 for Phase 3.

**Where**: New `check_link_density()` function + `Sparse Pages` section in lint report.

## Design Notes

- Both features are **read-only** — no wiki mutation
- Phantom hub detection intentionally does NOT auto-create pages (that would amplify LLM-hallucinated links). It surfaces candidates for human/agent review
- `from __future__ import annotations` added to `build_graph.py` for Python 3.9 compatibility

## Related

- Phase 1: #26 (graph health report) ✅ merged
- Phase 2: #27 (graph-aware lint) ✅ merged  
- Phase 3: auto-linking — still open for design
- #23 (wiki entropy RFC) — phantom hubs feed compaction decisions