### PR TITLE
feat: add tools/health.py — deterministic structural checks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,8 @@ Describe what you want in plain English:
 Or use shorthand triggers:
 - `ingest <file>` → runs the Ingest Workflow
 - `query: <question>` → runs the Query Workflow
-- `lint` → runs the Lint Workflow
+- `health` → runs the Health Workflow (fast, every session)
+- `lint` → runs the Lint Workflow (expensive, periodic)
 - `build graph` → runs the Graph Workflow
 
 ---
@@ -31,7 +32,10 @@ wiki/         # Agent owns this layer entirely
   concepts/   # Ideas, frameworks, methods, theories
   syntheses/  # Saved query answers
 graph/        # Auto-generated graph data
-tools/        # Optional standalone Python scripts (require ANTHROPIC_API_KEY)
+tools/        # Standalone Python scripts
+  health.py   # Structural checks (deterministic, no LLM calls)
+  lint.py     # Content quality checks (uses LLM for semantic analysis)
+  build_graph.py  # Knowledge graph generation
 ```
 
 ---
@@ -171,6 +175,35 @@ Output a lint report and ask if the user wants it saved to `wiki/lint-report.md`
 
 ---
 
+## Health Workflow
+
+Triggered by: *"health"*
+
+Run: `python tools/health.py` (or `python tools/health.py --json` for machine-readable output)
+
+Fast structural integrity checks — **zero LLM calls**, safe to run every session:
+- **Empty / stub files** — pages with no content beyond frontmatter (rate-limit damage)
+- **Index sync** — `wiki/index.md` entries vs actual files on disk
+- **Log coverage** — source pages missing a corresponding `ingest` entry in `wiki/log.md`
+
+Output a health report. Use `--save` to write to `wiki/health-report.md`.
+
+### Health vs Lint Boundary
+
+| Dimension | `health` | `lint` |
+|---|---|---|
+| **Scope** | Structural integrity | Content quality |
+| **LLM calls** | Zero | Yes (semantic analysis) |
+| **Cost** | Free | Tokens |
+| **Frequency** | Every session, before other work | Every 10-15 ingests |
+| **Checks** | Empty files, index sync, log sync | Orphans, broken links, contradictions, gaps |
+| **Tool** | `tools/health.py` | `tools/lint.py` |
+| **Run order** | First (pre-flight) | After health passes |
+
+> Run `health` first — linting an empty file wastes tokens.
+
+---
+
 ## Graph Workflow
 
 Triggered by: *"build graph"*
@@ -217,4 +250,4 @@ If Python/deps unavailable, build manually:
 
 `## [YYYY-MM-DD] <operation> | <title>`
 
-Operations: `ingest`, `query`, `lint`, `graph`
+Operations: `ingest`, `query`, `health`, `lint`, `graph`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,8 @@ This wiki is maintained entirely by Claude Code. No API key or Python scripts ne
 |---|---|
 | `/wiki-ingest` | `ingest raw/my-article.md` |
 | `/wiki-query` | `query: what are the main themes?` |
-| `/wiki-lint` | `lint the wiki` |
+| `/wiki-health` | `health` (fast, every session) |
+| `/wiki-lint` | `lint the wiki` (expensive, periodic) |
 | `/wiki-graph` | `build the knowledge graph` |
 
 Or just describe what you want in plain English:
@@ -34,7 +35,10 @@ wiki/         # Claude owns this layer entirely
   concepts/   # Ideas, frameworks, methods, theories
   syntheses/  # Saved query answers
 graph/        # Auto-generated graph data
-tools/        # Optional standalone Python scripts (require ANTHROPIC_API_KEY)
+tools/        # Standalone Python scripts
+  health.py   # Structural checks (deterministic, no LLM calls)
+  lint.py     # Content quality checks (uses LLM for semantic analysis)
+  build_graph.py  # Knowledge graph generation
 ```
 
 ---
@@ -174,6 +178,35 @@ Output a lint report and ask if the user wants it saved to `wiki/lint-report.md`
 
 ---
 
+## Health Workflow
+
+Triggered by: *"health"* or `/wiki-health`
+
+Run: `python tools/health.py` (or `python tools/health.py --json` for machine-readable output)
+
+Fast structural integrity checks — **zero LLM calls**, safe to run every session:
+- **Empty / stub files** — pages with no content beyond frontmatter (rate-limit damage)
+- **Index sync** — `wiki/index.md` entries vs actual files on disk
+- **Log coverage** — source pages missing a corresponding `ingest` entry in `wiki/log.md`
+
+Output a health report. Use `--save` to write to `wiki/health-report.md`.
+
+### Health vs Lint Boundary
+
+| Dimension | `health` | `lint` |
+|---|---|---|
+| **Scope** | Structural integrity | Content quality |
+| **LLM calls** | Zero | Yes (semantic analysis) |
+| **Cost** | Free | Tokens |
+| **Frequency** | Every session, before other work | Every 10-15 ingests |
+| **Checks** | Empty files, index sync, log sync | Orphans, broken links, contradictions, gaps |
+| **Tool** | `tools/health.py` | `tools/lint.py` |
+| **Run order** | First (pre-flight) | After health passes |
+
+> Run `health` first — linting an empty file wastes tokens.
+
+---
+
 ## Graph Workflow
 
 Triggered by: *"build the knowledge graph"* or `/wiki-graph`
@@ -228,4 +261,4 @@ Each entry starts with `## [YYYY-MM-DD] <operation> | <title>` so it's grep-pars
 grep "^## \[" wiki/log.md | tail -10
 ```
 
-Operations: `ingest`, `query`, `lint`, `graph`
+Operations: `ingest`, `query`, `health`, `lint`, `graph`

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -13,7 +13,8 @@ Describe what you want in plain English:
 Or use shorthand triggers:
 - `ingest <file>` → runs the Ingest Workflow
 - `query: <question>` → runs the Query Workflow
-- `lint` → runs the Lint Workflow
+- `health` → runs the Health Workflow (fast, every session)
+- `lint` → runs the Lint Workflow (expensive, periodic)
 - `build graph` → runs the Graph Workflow
 
 ---
@@ -31,7 +32,10 @@ wiki/         # Agent owns this layer entirely
   concepts/   # Ideas, frameworks, methods, theories
   syntheses/  # Saved query answers
 graph/        # Auto-generated graph data
-tools/        # Optional standalone Python scripts
+tools/        # Standalone Python scripts
+  health.py   # Structural checks (deterministic, no LLM calls)
+  lint.py     # Content quality checks (uses LLM for semantic analysis)
+  build_graph.py  # Knowledge graph generation
 ```
 
 ---
@@ -155,6 +159,35 @@ Triggered by: *"query: <question>"*
 Triggered by: *"lint"*
 
 Check for: orphan pages, broken links, contradictions, stale content, missing entity pages, data gaps.
+
+---
+
+## Health Workflow
+
+Triggered by: *"health"*
+
+Run: `python tools/health.py` (or `python tools/health.py --json` for machine-readable output)
+
+Fast structural integrity checks — **zero LLM calls**, safe to run every session:
+- **Empty / stub files** — pages with no content beyond frontmatter (rate-limit damage)
+- **Index sync** — `wiki/index.md` entries vs actual files on disk
+- **Log coverage** — source pages missing a corresponding `ingest` entry in `wiki/log.md`
+
+Output a health report. Use `--save` to write to `wiki/health-report.md`.
+
+### Health vs Lint Boundary
+
+| Dimension | `health` | `lint` |
+|---|---|---|
+| **Scope** | Structural integrity | Content quality |
+| **LLM calls** | Zero | Yes (semantic analysis) |
+| **Cost** | Free | Tokens |
+| **Frequency** | Every session, before other work | Every 10-15 ingests |
+| **Checks** | Empty files, index sync, log sync | Orphans, broken links, contradictions, gaps |
+| **Tool** | `tools/health.py` | `tools/lint.py` |
+| **Run order** | First (pre-flight) | After health passes |
+
+> Run `health` first — linting an empty file wastes tokens.
 
 ---
 

--- a/tools/health.py
+++ b/tools/health.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+"""
+Structural health checks for the LLM Wiki.
+
+Unlike lint.py (which includes expensive LLM-powered semantic analysis),
+health.py is purely deterministic — zero API calls, fast enough to run
+every session.
+
+Usage:
+    python tools/health.py              # print report to stdout
+    python tools/health.py --save       # also save to wiki/health-report.md
+    python tools/health.py --json       # machine-readable output
+
+Checks:
+  - Empty / stub files (pages with no real content beyond frontmatter)
+  - Index sync (wiki/index.md entries vs actual files on disk)
+  - Log coverage (source pages without a corresponding log entry)
+
+Design boundary (see AGENTS.md):
+  health.py = structural integrity, deterministic, run every session
+  lint.py   = content quality, semantic (LLM), run every 10-15 ingests
+"""
+
+import re
+import sys
+import json
+import argparse
+from pathlib import Path
+from datetime import date
+
+REPO_ROOT = Path(__file__).parent.parent
+WIKI_DIR = REPO_ROOT / "wiki"
+INDEX_FILE = WIKI_DIR / "index.md"
+LOG_FILE = WIKI_DIR / "log.md"
+
+# Minimum content length (excluding frontmatter) to not be considered a stub
+STUB_THRESHOLD_CHARS = 100
+
+
+def read_file(path: Path) -> str:
+    return path.read_text(encoding="utf-8") if path.exists() else ""
+
+
+def all_wiki_pages() -> list[Path]:
+    """All .md files in wiki/, excluding meta files."""
+    exclude = {"index.md", "log.md", "lint-report.md", "health-report.md"}
+    return [p for p in WIKI_DIR.rglob("*.md") if p.name not in exclude]
+
+
+def strip_frontmatter(content: str) -> str:
+    """Remove YAML frontmatter (--- ... ---) from content."""
+    if content.startswith("---"):
+        end = content.find("---", 3)
+        if end != -1:
+            return content[end + 3:].strip()
+    return content.strip()
+
+
+# ── Check: Empty / Stub files ───────────────────────────────────────
+
+def check_empty_files(pages: list[Path], threshold: int = STUB_THRESHOLD_CHARS) -> list[dict]:
+    """Find wiki pages that are empty or contain only frontmatter / minimal content."""
+    results = []
+    for p in pages:
+        raw = read_file(p)
+        body = strip_frontmatter(raw)
+        if len(body) < threshold:
+            results.append({
+                "path": str(p.relative_to(REPO_ROOT)),
+                "total_bytes": len(raw),
+                "body_bytes": len(body),
+                "status": "empty" if len(body) == 0 else "stub",
+            })
+    results.sort(key=lambda x: x["body_bytes"])
+    return results
+
+
+# ── Check: Index sync ───────────────────────────────────────────────
+
+def _parse_index_links(index_content: str) -> set[str]:
+    """Extract markdown link targets from index.md.
+
+    Matches patterns like: [Title](sources/slug.md)
+    Returns set of relative paths (e.g. 'sources/slug.md').
+    """
+    return set(re.findall(r'\[.*?\]\(([^)]+\.md)\)', index_content))
+
+
+def check_index_sync(pages: list[Path]) -> dict:
+    """Compare wiki/index.md entries against actual files on disk.
+
+    Returns:
+        {
+            "in_index_not_on_disk": [...],   # stale index entries
+            "on_disk_not_in_index": [...],   # missing from index
+        }
+    """
+    index_content = read_file(INDEX_FILE)
+    index_links = _parse_index_links(index_content)
+
+    # Normalize index links to absolute paths for comparison
+    # overview.md is listed under ## Overview, not in the per-type sections.
+    # Exclude it from both sides to avoid false positives.
+    meta_pages = {"overview.md"}
+
+    index_paths = set()
+    for link in index_links:
+        resolved = (WIKI_DIR / link).resolve()
+        if Path(link).name not in meta_pages:
+            index_paths.add(resolved)
+
+    disk_paths = set()
+    for p in pages:
+        if p.name not in meta_pages:
+            disk_paths.add(p.resolve())
+
+    in_index_not_on_disk = [
+        str(p.relative_to(REPO_ROOT)) for p in sorted(index_paths - disk_paths)
+        if REPO_ROOT in p.parents or p == REPO_ROOT
+    ]
+    on_disk_not_in_index = [
+        str(p.relative_to(REPO_ROOT)) for p in sorted(disk_paths - index_paths)
+    ]
+
+    return {
+        "in_index_not_on_disk": in_index_not_on_disk,
+        "on_disk_not_in_index": on_disk_not_in_index,
+    }
+
+
+# ── Check: Log coverage ────────────────────────────────────────────
+
+def _parse_log_entries(log_content: str) -> set[str]:
+    """Extract page titles/slugs from log.md entries.
+
+    Log format: ## [YYYY-MM-DD] ingest | Title Here
+    Returns set of lowercase title strings.
+    """
+    return set(
+        m.group(1).strip().lower()
+        for m in re.finditer(r'^## \[\d{4}-\d{2}-\d{2}\] ingest \| (.+)$', log_content, re.MULTILINE)
+    )
+
+
+def check_log_coverage(pages: list[Path]) -> list[dict]:
+    """Find source pages that have no corresponding ingest entry in log.md.
+
+    Only checks wiki/sources/*.md — entity/concept pages are created as
+    side-effects of ingest and don't need their own log entry.
+    """
+    log_content = read_file(LOG_FILE)
+    logged_titles = _parse_log_entries(log_content)
+
+    source_dir = WIKI_DIR / "sources"
+    if not source_dir.exists():
+        return []
+
+    missing = []
+    for p in sorted(source_dir.glob("*.md")):
+        # Try matching by slug (filename without .md) or by frontmatter title
+        slug = p.stem.lower().replace("-", " ").replace("_", " ")
+
+        # Also try extracting title from frontmatter
+        content = read_file(p)
+        title_match = re.search(r'^title:\s*["\']?(.+?)["\']?\s*$', content, re.MULTILINE)
+        fm_title = title_match.group(1).strip().lower() if title_match else ""
+
+        if slug not in logged_titles and fm_title not in logged_titles:
+            missing.append({
+                "path": str(p.relative_to(REPO_ROOT)),
+                "slug": p.stem,
+                "title": fm_title or p.stem,
+            })
+
+    return missing
+
+
+# ── Report Generation ───────────────────────────────────────────────
+
+def run_health() -> dict:
+    """Run all health checks, return structured results."""
+    pages = all_wiki_pages()
+
+    return {
+        "date": date.today().isoformat(),
+        "total_pages": len(pages),
+        "empty_files": check_empty_files(pages),
+        "index_sync": check_index_sync(pages),
+        "log_coverage": check_log_coverage(pages),
+    }
+
+
+def format_report(results: dict) -> str:
+    """Format health check results as markdown."""
+    lines = [
+        f"# Wiki Health Report — {results['date']}",
+        "",
+        f"Scanned {results['total_pages']} wiki pages. "
+        "Checks are purely structural (no LLM calls).",
+        "",
+    ]
+
+    # ── Empty / Stub Files
+    empty = results["empty_files"]
+    lines.append(f"## Empty / Stub Files ({len(empty)} found)")
+    lines.append("")
+    if empty:
+        lines.append("| Page | Total Bytes | Body Bytes | Status |")
+        lines.append("|---|---|---|---|")
+        for ef in empty:
+            emoji = "🔴" if ef["status"] == "empty" else "🟡"
+            lines.append(f"| `{ef['path']}` | {ef['total_bytes']} | {ef['body_bytes']} | {emoji} {ef['status']} |")
+    else:
+        lines.append("All pages have content beyond frontmatter. ✅")
+    lines.append("")
+
+    # ── Index Sync
+    isync = results["index_sync"]
+    stale = isync["in_index_not_on_disk"]
+    missing = isync["on_disk_not_in_index"]
+    total_issues = len(stale) + len(missing)
+    lines.append(f"## Index Sync ({total_issues} issues)")
+    lines.append("")
+
+    if stale:
+        lines.append("### Stale Index Entries (in index.md but no file on disk)")
+        for s in stale:
+            lines.append(f"- `{s}`")
+        lines.append("")
+
+    if missing:
+        lines.append("### Missing from Index (file exists but not in index.md)")
+        for m in missing:
+            lines.append(f"- `{m}`")
+        lines.append("")
+
+    if not stale and not missing:
+        lines.append("index.md is in sync with disk. ✅")
+        lines.append("")
+
+    # ── Log Coverage
+    log_missing = results["log_coverage"]
+    lines.append(f"## Log Coverage ({len(log_missing)} source pages without log entry)")
+    lines.append("")
+    if log_missing:
+        lines.append("These source pages have no corresponding `ingest` entry in log.md:")
+        lines.append("")
+        for lm in log_missing:
+            lines.append(f"- `{lm['path']}` — {lm['title']}")
+    else:
+        lines.append("All source pages have corresponding log entries. ✅")
+    lines.append("")
+
+    return "\n".join(lines)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Structural health checks for the LLM Wiki (deterministic, no LLM calls)"
+    )
+    parser.add_argument("--save", action="store_true",
+                        help="Save report to wiki/health-report.md")
+    parser.add_argument("--json", action="store_true",
+                        help="Output machine-readable JSON instead of markdown")
+    args = parser.parse_args()
+
+    results = run_health()
+
+    if args.json:
+        print(json.dumps(results, indent=2))
+    else:
+        report = format_report(results)
+        print(report)
+
+        if args.save:
+            report_path = WIKI_DIR / "health-report.md"
+            report_path.write_text(report, encoding="utf-8")
+            print(f"\nSaved: {report_path.relative_to(REPO_ROOT)}")


### PR DESCRIPTION
## What

Adds `tools/health.py` — a standalone Python script for **zero-LLM-call** structural integrity checks. Designed as the fast pre-flight check to run every session, before the heavier semantic lint.

### Checks implemented
- **Empty / stub files** — pages with no content beyond frontmatter (catches rate-limit damage)
- **Index sync** — `wiki/index.md` entries vs actual files on disk (catches stale entries + missing registrations)
- **Log coverage** — source pages without a corresponding `ingest` entry in `wiki/log.md`

### CLI
```bash
python tools/health.py          # markdown report to stdout
python tools/health.py --save   # also write to wiki/health-report.md
python tools/health.py --json   # machine-readable output
```

### Documentation
Updated **AGENTS.md**, **CLAUDE.md**, **GEMINI.md** with:
- Health Workflow section (triggers, usage)
- **Health vs Lint boundary table** — explicit scope separation to prevent future overlap
- `health` registered in operations list and shorthand triggers

### Context
Ref: #38 — responding to @lifeisfleetingcodes' request for help integrating deterministic checks into the toolchain. This PR provides the `tools/health.py` foundation that #38 can build its `/wiki-health` slash command on top of.

### Boundary table (from docs)

| Dimension | `health` | `lint` |
|---|---|---|
| **Scope** | Structural integrity | Content quality |
| **LLM calls** | Zero | Yes (semantic analysis) |
| **Cost** | Free | Tokens |
| **Frequency** | Every session | Every 10-15 ingests |
| **Run order** | First (pre-flight) | After health passes |