### PR TITLE
fix: pin litellm and networkx versions to prevent supply chain attacks

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
-litellm>=1.0.0
-networkx>=3.2
+# litellm 1.82.7–1.82.8 were compromised in a supply chain attack (Mar 2026).
+# Pin to a verified safe version. See: https://github.com/SamurAIGPT/llm-wiki-agent/issues/41
+litellm~=1.83.10
+networkx~=3.6.1


### PR DESCRIPTION
## Summary

Fixes #41

Pin `litellm` and `networkx` to specific safe versions using the `~=` (compatible release) operator to mitigate supply chain attack risks.

## Background

`litellm` versions **1.82.7** and **1.82.8** (published March 24, 2026) were compromised in a supply chain attack that could exfiltrate API keys, SSH keys, and environment variables from affected environments. See [Comet Blog analysis](https://www.comet.com/site/blog/litellm-supply-chain-attack/).

The previous `requirements.txt` used `litellm>=1.0.0`, allowing `pip` to pull any version including the malicious ones.

## Changes

| Package | Before | After |
|---------|--------|-------|
| `litellm` | `>=1.0.0` | `~=1.83.10` |
| `networkx` | `>=3.2` | `~=3.6.1` |

### Why `~=` instead of `==`?

The `~=` (compatible release) operator allows patch-level updates (e.g. `1.83.10` → `1.83.11`) while blocking major/minor version jumps. This balances security (no unexpected major changes) with maintainability (automatic bugfix/security patches within the pinned minor version).

## Verification

- `litellm 1.83.10` is a verified safe release from the official maintainers, published via their secured CI/CD pipeline post-incident.
- `networkx 3.6.1` is the current latest stable release.