### PR TITLE
feat(ingest): native multi-format ingest — PDF, DOCX, PPTX, and 17 more

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,8 +62,10 @@ Use `[[PageName]]` wikilinks to link to other wiki pages.
 
 Triggered by: *"ingest <file>"*
 
+**Supported formats:** Markdown (`.md`) is ingested directly. Non-markdown files (`.pdf`, `.docx`, `.pptx`, `.xlsx`, `.html`, `.txt`, `.csv`, `.json`, `.xml`, `.rst`, `.rtf`, `.epub`, `.ipynb`, `.yaml`, `.yml`, `.tsv`, `.wav`, `.mp3`) are auto-converted to markdown via [markitdown](https://github.com/microsoft/markitdown) before ingestion. Use `--no-convert` to skip auto-conversion.
+
 Steps (in order):
-1. Read the source document fully
+1. Read the source document fully (auto-convert if non-markdown)
 2. Read `wiki/index.md` and `wiki/overview.md` for current wiki context
 3. Write `wiki/sources/<slug>.md` — use the source page format below
 4. Update `wiki/index.md` — add entry under Sources section

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,8 +65,10 @@ Use `[[PageName]]` wikilinks to link to other wiki pages.
 
 Triggered by: *"ingest <file>"* or `/wiki-ingest`
 
+**Supported formats:** Markdown (`.md`) ingested directly. Non-markdown files (`.pdf`, `.docx`, `.pptx`, `.xlsx`, `.html`, `.txt`, `.csv`, `.json`, `.xml`, `.rst`, `.rtf`, `.epub`, `.ipynb`, `.yaml`, `.yml`, `.tsv`, `.wav`, `.mp3`) auto-converted to markdown via [markitdown](https://github.com/microsoft/markitdown) before ingestion. Use `--no-convert` to skip auto-conversion.
+
 Steps (in order):
-1. Read the source document fully using the Read tool
+1. Read the source document fully using the Read tool (auto-convert if non-markdown)
 2. Read `wiki/index.md` and `wiki/overview.md` for current wiki context
 3. Write `wiki/sources/<slug>.md` — use the source page format below
 4. Update `wiki/index.md` — add entry under Sources section

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -62,7 +62,9 @@ Use `[[PageName]]` wikilinks to link to other wiki pages.
 
 Triggered by: *"ingest <file>"*
 
-1. Read the source document fully
+**Supported formats:** `.md` ingested directly. Non-markdown files (`.pdf`, `.docx`, `.pptx`, `.xlsx`, `.html`, `.txt`, `.csv`, `.json`, `.xml`, `.rst`, `.rtf`, `.epub`, `.ipynb`, `.yaml`, `.yml`, `.tsv`, `.wav`, `.mp3`) auto-converted via markitdown. Use `--no-convert` to skip.
+
+1. Read the source document fully (auto-convert if non-markdown)
 2. Read `wiki/index.md` and `wiki/overview.md` for current wiki context
 3. Write `wiki/sources/<slug>.md` (source page format below)
 4. Update `wiki/index.md` — add entry under Sources

--- a/README.md
+++ b/README.md
@@ -47,7 +47,9 @@ gemini      # reads GEMINI.md
 All agents understand natural language and shorthand triggers:
 
 ```
-ingest raw/papers/my-paper.md              # ingest a source into the wiki
+ingest raw/papers/my-paper.md              # ingest a markdown source
+ingest report.pdf                          # auto-converts to .md, then ingests
+ingest slides.pptx notes.docx              # batch, mixed formats
 query: what are the main themes?           # synthesize answer from wiki pages
 lint                                       # find orphans, contradictions, gaps
 build graph                                # build graph.html from all wikilinks
@@ -63,7 +65,7 @@ Plain English works too:
 
 **Claude Code** also provides `/wiki-ingest`, `/wiki-query`, `/wiki-lint`, `/wiki-graph` as slash commands (via `.claude/commands/`). These are Claude Code-specific — other agents use the natural language triggers above, which work identically.
 
-Works with any markdown source — articles, papers, book chapters, meeting notes, journal entries, research summaries.
+Works with markdown, PDF, DOCX, PPTX, XLSX, HTML, TXT, CSV, JSON, XML, RST, EPUB, and more. Non-markdown files are auto-converted via [markitdown](https://github.com/microsoft/markitdown) at ingest time — no separate step needed.
 
 ## What You Get
 
@@ -226,52 +228,62 @@ If you want to keep the LLM Wiki Agent repository separate from your main person
 - **Graph View:** Filter out `index.md` and `log.md` (e.g. `-file:index.md -file:log.md`) to avoid them becoming gravity wells in your Obsidian graph.
 - **Dataview:** Use the community plugin [Dataview](https://blacksmithgu.github.io/obsidian-dataview/) to query the YAML frontmatter the agent automatically injects (e.g., `type: source`, `tags: [diary]`).
 
-## Converting Files, PDFs, and arXiv Papers
+## Multi-Format Ingest
 
-The wiki ingests Markdown files. Use `files_to_md.py` to convert files or `tools/pdf2md.py` to convert PDFs and arXiv papers before ingesting:
-
-```bash
-python tools/files_to_md.py --input_dir  ../raw/
-
-# optionally, if users would like to delete source files:
-python tools/files_to_md.py --input_dir ../raw/ --delete_source
-```
-
-Or if users want to use papers from arXiv:
+Drop any supported file directly into `ingest` — no separate conversion step needed:
 
 ```bash
-# arXiv papers — by ID or URL (uses arxiv2md, no PDF parsing needed)
-python tools/pdf2md.py 2401.12345
-python tools/pdf2md.py https://arxiv.org/abs/2401.12345
-
-# Local PDFs — auto-selects the best available backend
-python tools/pdf2md.py paper.pdf
-python tools/pdf2md.py paper.pdf --backend marker     # complex multi-column layouts
-python tools/pdf2md.py paper.pdf --backend pymupdf4llm # fast, lightweight
-
-# Custom output path
-python tools/pdf2md.py paper.pdf -o raw/papers/my-paper.md
+# These all work — auto-converted at ingest time
+ingest report.pdf
+ingest meeting-notes.docx
+ingest slides.pptx
+ingest data.xlsx
+ingest page.html
+ingest raw/mixed-folder/          # recursively finds all supported files
 ```
 
-Then ingest as usual:
+**Supported formats:**
+`.md` `.pdf` `.docx` `.pptx` `.xlsx` `.xls` `.html` `.htm` `.txt` `.csv` `.json` `.xml` `.rst` `.rtf` `.epub` `.ipynb` `.yaml` `.yml` `.tsv` `.wav` `.mp3`
+
+Non-markdown files are auto-converted via [markitdown](https://github.com/microsoft/markitdown). Use `--no-convert` to skip auto-conversion and process only `.md` files.
+
+### arXiv Papers (Advanced)
+
+For arXiv papers, use `tools/pdf2md.py` for higher-fidelity conversion:
+
+```bash
+python tools/pdf2md.py 2401.12345                      # by arXiv ID
+python tools/pdf2md.py https://arxiv.org/abs/2401.12345 # by URL
+python tools/pdf2md.py paper.pdf --backend marker       # complex multi-column PDFs
+```
+
+Then ingest the resulting `.md`:
 ```
 ingest raw/papers/my-paper.md
 ```
 
-Install at least one conversion backend:
+### Batch Directory Conversion (Advanced)
 
-| Backend | Install | Best for |
+To pre-convert an entire directory (useful for bulk imports):
+```bash
+python tools/file_to_md.py --input_dir raw/imports/
+python tools/file_to_md.py --input_dir raw/imports/ --delete_source  # remove originals
+```
+
+### Optional Dependencies
+
+| Package | Install | Used for |
 |---|---|---|
-| [arxiv2md](https://github.com/ryansingman/arxiv2md) | `pip install arxiv2markdown` | arXiv papers (uses structured source, avoids PDF parsing) |
-| [Marker](https://github.com/VikParuchuri/marker) | `pip install marker-pdf` | Complex academic PDFs with multi-column layouts, tables, equations |
-| [PyMuPDF4LLM](https://github.com/pymupdf/RAG) | `pip install pymupdf4llm` | Fast extraction from native-text PDFs (no GPU needed) |
-[markitdown](https://github.com/microsoft/markitdown) | `pip install markitdown` | for converting files to markdown
-[tqdm](https://github.com/tqdm/tqdm) | `pip install tqdm` | for progress bar during conversion
+| [markitdown](https://github.com/microsoft/markitdown) | `pip install markitdown` | Auto-conversion of non-.md files (required for multi-format ingest) |
+| [arxiv2md](https://github.com/ryansingman/arxiv2md) | `pip install arxiv2markdown` | arXiv papers via structured source |
+| [Marker](https://github.com/VikParuchuri/marker) | `pip install marker-pdf` | Complex academic PDFs with multi-column layouts |
+| [PyMuPDF4LLM](https://github.com/pymupdf/RAG) | `pip install pymupdf4llm` | Fast PDF extraction (no GPU needed) |
+| [tqdm](https://github.com/tqdm/tqdm) | `pip install tqdm` | Progress bar for batch directory conversion |
 
 ## Tips
 
-- Use `tools/files_to_md.py` to convert files to Markdown before injesting — see [Converting Files, PDFs, and arXiv Papers](#converting-files-pdfs-and-arxiv-papers)
-- Use `tools/pdf2md.py` to convert PDFs and arXiv papers to Markdown before ingesting — see [Converting Files, PDFs, and arXiv Papers](#converting-files-pdfs-and-arxiv-papers)
+- Just drop files (PDF, DOCX, etc.) into `raw/` and `ingest` them — conversion is automatic
+- For arXiv papers, `tools/pdf2md.py` gives higher-fidelity output than generic markitdown conversion
 - Query answers are shown first — the agent then asks if you want to file them as synthesis pages. Your explorations compound just like ingested sources
 - The wiki is a git repo — version history for free
 - Standalone Python scripts in `tools/` work without a coding agent (require `ANTHROPIC_API_KEY`)

--- a/tools/ingest.py
+++ b/tools/ingest.py
@@ -5,7 +5,14 @@ Ingest a source document into the LLM Wiki.
 Usage:
     python tools/ingest.py <path-to-source>
     python tools/ingest.py raw/articles/my-article.md
-    python tools/ingest.py --validate-only   # run validation on existing wiki
+    python tools/ingest.py report.pdf                  # auto-converts to .md
+    python tools/ingest.py slides.pptx notes.docx       # batch, mixed formats
+    python tools/ingest.py raw/mixed/ --no-convert      # skip auto-conversion
+    python tools/ingest.py --validate-only              # run validation only
+
+Supported formats (auto-converted via markitdown):
+    .pdf .docx .pptx .xlsx .html .htm .txt .csv .json .xml
+    .rst .rtf .epub .ipynb .yaml .yml .tsv .wav .mp3
 
 The LLM reads the source, extracts knowledge, and updates the wiki:
   - Creates wiki/sources/<slug>.md
@@ -22,6 +29,8 @@ import sys
 import json
 import hashlib
 import re
+import shutil
+import tempfile
 from pathlib import Path
 from collections import defaultdict
 from datetime import date
@@ -31,6 +40,17 @@ WIKI_DIR = REPO_ROOT / "wiki"
 LOG_FILE = WIKI_DIR / "log.md"
 INDEX_FILE = WIKI_DIR / "index.md"
 OVERVIEW_FILE = WIKI_DIR / "overview.md"
+
+# File extensions that can be auto-converted to markdown via markitdown.
+# .md files are ingested directly without conversion.
+CONVERTIBLE_EXTENSIONS = {
+    ".pdf", ".docx", ".pptx", ".xlsx", ".xls",
+    ".html", ".htm", ".txt", ".csv", ".json", ".xml",
+    ".rst", ".rtf", ".epub", ".ipynb",
+    ".yaml", ".yml", ".tsv",
+    ".wav", ".mp3",  # audio transcription via markitdown
+}
+ALL_SUPPORTED_EXTENSIONS = {".md"} | CONVERTIBLE_EXTENSIONS
 SCHEMA_FILE = REPO_ROOT / "CLAUDE.md"
 
 
@@ -169,11 +189,59 @@ def validate_ingest(changed_pages: list[str] | None = None) -> dict:
     return {"broken_links": broken_links, "unindexed": unindexed}
 
 
-def ingest(source_path: str):
+def convert_to_md(source: Path) -> Path:
+    """Convert a non-markdown file to .md using markitdown.
+
+    Returns the path to the converted .md file (placed next to the original
+    with a .md extension, or in a temp location if the source dir is read-only).
+    """
+    try:
+        from markitdown import MarkItDown
+    except ImportError:
+        print("Error: markitdown not installed (needed to convert non-.md files).")
+        print("  Install with: pip install markitdown")
+        sys.exit(1)
+
+    md = MarkItDown(enable_plugins=False)
+    try:
+        result = md.convert(str(source))
+    except Exception as e:
+        print(f"Error: failed to convert '{source.name}': {e}")
+        sys.exit(1)
+
+    # Write converted output next to source as <name>.md
+    output = source.with_suffix(".md")
+    try:
+        output.write_text(result.text_content, encoding="utf-8")
+    except OSError:
+        # Fallback: source directory may be read-only
+        tmp = Path(tempfile.mkdtemp()) / f"{source.stem}.md"
+        tmp.write_text(result.text_content, encoding="utf-8")
+        output = tmp
+
+    print(f"  ✓ Converted {source.name} → {output.name}")
+    return output
+
+
+def ingest(source_path: str, auto_convert: bool = True):
     source = Path(source_path)
     if not source.exists():
         print(f"Error: file not found: {source_path}")
         sys.exit(1)
+
+    # Auto-convert non-markdown files
+    converted_path = None
+    if source.suffix.lower() != ".md":
+        if not auto_convert:
+            print(f"  Skipping non-.md file (--no-convert): {source.name}")
+            return
+        if source.suffix.lower() not in CONVERTIBLE_EXTENSIONS:
+            print(f"  ⚠️  Unsupported format: {source.suffix} — skipping {source.name}")
+            print(f"       Supported: {', '.join(sorted(ALL_SUPPORTED_EXTENSIONS))}")
+            return
+        print(f"  Converting {source.name} to markdown...")
+        converted_path = convert_to_md(source)
+        source = converted_path
 
     source_content = source.read_text(encoding="utf-8")
     source_hash = sha256(source_content)
@@ -328,27 +396,37 @@ if __name__ == "__main__":
             print("All pages are indexed.")
         sys.exit(0)
 
-    if len(sys.argv) < 2:
+    # Parse flags
+    no_convert = "--no-convert" in sys.argv
+    args = [a for a in sys.argv[1:] if not a.startswith("--")]
+
+    if not args:
         print("Usage: python tools/ingest.py <path-to-source> [path2 ...] [dir1 ...]")
         print("       python tools/ingest.py --validate-only")
+        print("       python tools/ingest.py --no-convert  # skip auto-conversion of non-.md files")
+        print(f"\nSupported formats: {', '.join(sorted(ALL_SUPPORTED_EXTENSIONS))}")
         sys.exit(1)
-        
+
     paths_to_process = []
-    for arg in sys.argv[1:]:
+    for arg in args:
         p = Path(arg)
-        if p.is_file() and p.suffix == ".md":
-            paths_to_process.append(p)
+        if p.is_file():
+            ext = p.suffix.lower()
+            if ext in ALL_SUPPORTED_EXTENSIONS:
+                paths_to_process.append(p)
+            else:
+                print(f"  ⚠️  Skipping unsupported format: {p.name} ({ext})")
         elif p.is_dir():
-            for f in p.rglob("*.md"):
-                if f.is_file():
+            for f in p.rglob("*"):
+                if f.is_file() and f.suffix.lower() in ALL_SUPPORTED_EXTENSIONS:
                     paths_to_process.append(f)
         else:
             import glob
             for f in glob.glob(arg, recursive=True):
                 g_p = Path(f)
-                if g_p.is_file() and g_p.suffix == ".md":
+                if g_p.is_file() and g_p.suffix.lower() in ALL_SUPPORTED_EXTENSIONS:
                     paths_to_process.append(g_p)
-                    
+
     # Deduplicate while preserving order
     unique_paths = []
     seen = set()
@@ -359,11 +437,12 @@ if __name__ == "__main__":
             unique_paths.append(p)
 
     if not unique_paths:
-        print("Error: no markdown files found to ingest.")
+        print("Error: no supported files found to ingest.")
+        print(f"Supported formats: {', '.join(sorted(ALL_SUPPORTED_EXTENSIONS))}")
         sys.exit(1)
-        
+
     if len(unique_paths) > 1:
         print(f"Batch mode: found {len(unique_paths)} files to ingest.")
-        
+
     for p in unique_paths:
-        ingest(str(p))
+        ingest(str(p), auto_convert=not no_convert)


### PR DESCRIPTION
## Summary

Closes #43

`ingest.py` now natively supports **21 file formats** — no separate conversion step needed.

### Before (md-only)
```bash
python tools/file_to_md.py --input_dir raw/   # step 1: convert
ingest raw/papers/my-paper.md                  # step 2: ingest
```

### After (any format)
```bash
ingest report.pdf
ingest slides.pptx notes.docx
ingest raw/mixed-folder/          # recursively finds all supported files
```

### Supported formats (21 total)

| Category | Count | Extensions |
|---|---|---|
| Native | 1 | `.md` |
| Auto-converted | 20 | `.pdf` `.docx` `.pptx` `.xlsx` `.xls` `.html` `.htm` `.txt` `.csv` `.json` `.xml` `.rst` `.rtf` `.epub` `.ipynb` `.yaml` `.yml` `.tsv` `.wav` `.mp3` |

Non-markdown files are auto-converted via [markitdown](https://github.com/microsoft/markitdown) at ingest time.

### Changes

- **`tools/ingest.py`**: Add `convert_to_md()` function, `CONVERTIBLE_EXTENSIONS` set, `--no-convert` flag. CLI now accepts all supported formats and auto-converts before ingesting.
- **`AGENTS.md`**, **`CLAUDE.md`**, **`GEMINI.md`**: Document supported formats in Ingest Workflow section.
- **`README.md`**: Rewrite "Converting Files" as "Multi-Format Ingest" with streamlined examples. Keep `pdf2md.py` and `file_to_md.py` as advanced options.

### Backward compatibility

- `.md` files work exactly as before — zero behavior change.
- `markitdown` is only required when ingesting non-`.md` files. Clear error message if missing.
- `--no-convert` flag available to opt out of auto-conversion.
- Existing `file_to_md.py` and `pdf2md.py` tools preserved for advanced use cases.