### PR TITLE
chore: add defuddle skill and skills-lock.json

### DIFF
--- a/.claude/skills/defuddle/SKILL.md
+++ b/.claude/skills/defuddle/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: defuddle
+description: Extract clean markdown content from web pages using Defuddle CLI, removing clutter and navigation to save tokens. Use instead of WebFetch when the user provides a URL to read or analyze, for online documentation, articles, blog posts, or any standard web page. Do NOT use for URLs ending in .md — those are already markdown, use WebFetch directly.
+---
+
+# Defuddle
+
+Use Defuddle CLI to extract clean readable content from web pages. Prefer over WebFetch for standard web pages — it removes navigation, ads, and clutter, reducing token usage.
+
+If not installed: `npm install -g defuddle`
+
+## Usage
+
+Always use `--md` for markdown output:
+
+```bash
+defuddle parse <url> --md
+```
+
+Save to file:
+
+```bash
+defuddle parse <url> --md -o content.md
+```
+
+Extract specific metadata:
+
+```bash
+defuddle parse <url> -p title
+defuddle parse <url> -p description
+defuddle parse <url> -p domain
+```
+
+## Output formats
+
+| Flag | Format |
+|------|--------|
+| `--md` | Markdown (default choice) |
+| `--json` | JSON with both HTML and markdown |
+| (none) | HTML |
+| `-p <name>` | Specific metadata property |

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "skills": {
+    "defuddle": {
+      "source": "kepano/obsidian-skills",
+      "sourceType": "github",
+      "skillPath": "skills/defuddle/SKILL.md",
+      "computedHash": "0ed68bc3e818ba0e6b8d192357ea3daaf552a3893f8854e7fd43c06831f91323"
+    }
+  }
+}


### PR DESCRIPTION
Add defuddle skill from kepano/obsidian-skills and skills-lock.json to track installed skills.