### PR TITLE
fix: YAML-aware title parsing in health.py, add word-boundary clip()

### DIFF
--- a/tools/health.py
+++ b/tools/health.py
@@ -144,6 +144,25 @@ def _parse_log_entries(log_content: str) -> set[str]:
     )
 
 
+def _parse_frontmatter_title(content: str) -> str:
+    """Extract and lightly unescape a frontmatter title scalar.
+
+    Handles YAML-escaped quotes (e.g. title: "few \"people\" laptop")
+    so that log coverage matching doesn't false-positive on escaped strings.
+    """
+    match = re.search(r'^title:\s*(.+?)\s*$', content, re.MULTILINE)
+    if not match:
+        return ""
+    raw = match.group(1).strip()
+    # Strip surrounding quotes and unescape inner ones
+    if len(raw) >= 2 and raw[0] == raw[-1] == '"':
+        raw = raw[1:-1]
+        raw = raw.replace(r'\"', '"').replace(r"\'", "'").replace(r"\\", "\\")
+    elif len(raw) >= 2 and raw[0] == raw[-1] == "'":
+        raw = raw[1:-1].replace("''", "'")
+    return raw.strip().lower()
+
+
 def check_log_coverage(pages: list[Path]) -> list[dict]:
     """Find source pages that have no corresponding ingest entry in log.md.
 
@@ -162,10 +181,8 @@ def check_log_coverage(pages: list[Path]) -> list[dict]:
         # Try matching by slug (filename without .md) or by frontmatter title
         slug = p.stem.lower().replace("-", " ").replace("_", " ")
 
-        # Also try extracting title from frontmatter
         content = read_file(p)
-        title_match = re.search(r'^title:\s*["\']?(.+?)["\']?\s*$', content, re.MULTILINE)
-        fm_title = title_match.group(1).strip().lower() if title_match else ""
+        fm_title = _parse_frontmatter_title(content)
 
         if slug not in logged_titles and fm_title not in logged_titles:
             missing.append({

--- a/tools/ingest.py
+++ b/tools/ingest.py
@@ -58,6 +58,14 @@ def sha256(text: str) -> str:
     return hashlib.sha256(text.encode()).hexdigest()[:16]
 
 
+def clip(text: str, limit: int = 260) -> str:
+    """Truncate text at word boundary instead of mid-word."""
+    if len(text) <= limit:
+        return text
+    clipped = text[: limit - 3].rsplit(" ", 1)[0].rstrip()
+    return clipped + "..."
+
+
 def read_file(path: Path) -> str:
     return path.read_text(encoding="utf-8") if path.exists() else ""
 


### PR DESCRIPTION
## Problem

`health.py` uses a simple regex to extract frontmatter titles for log coverage matching:

```python
title_match = re.search(r'^title:\s*["\']?(.+?)["\']?\s*$', content, re.MULTILINE)
```

This fails on YAML-escaped quotes (e.g. `title: "few \"people\" laptop"`), causing false-positive log coverage reports. Reported in #47.

Additionally, text truncation in the ingest pipeline uses hard byte offsets (`text[:260]`) which can cut mid-word.

## Changes

### `tools/health.py`
- Add `_parse_frontmatter_title()` that properly handles YAML-escaped quotes:
  - Double-quoted strings with `\"` unescaping
  - Single-quoted strings with `''` unescaping
  - Falls back to raw content for unquoted titles
- Replaces the inline regex in `check_log_coverage()`

### `tools/ingest.py`
- Add `clip(text, limit)` utility for word-boundary truncation
- Truncates at the last space before the limit, appends `...`

## Testing

```python
# health.py YAML parsing
_parse_frontmatter_title('title: "few \\"people\\" laptop"')  # → 'few "people" laptop'
_parse_frontmatter_title("title: 'few people laptop'")        # → 'few people laptop'
_parse_frontmatter_title('title: simple title')                # → 'simple title'

# ingest.py clip()
clip('word ' * 60, 260)  # ends with '...', ≤ 260 chars, word boundary
clip('short', 260)        # unchanged
```

Closes #47