### PR TITLE
fix: correct script reference in lint.py missing entity action hint

### DIFF
--- a/tools/lint.py
+++ b/tools/lint.py
@@ -350,7 +350,7 @@ Be specific — name the exact pages and claims involved.
 
     if missing_entities:
         report_lines.append("### Missing Entity Pages (mentioned 3+ times but no page)")
-        report_lines.append("> [!warning] Action Required\n> Run `python3 generate_missing_entities.py` to automatically materialize these missing hubs.")
+        report_lines.append("> [!warning] Action Required\n> Run `python3 tools/heal.py` to automatically materialize these missing entity pages.")
         for name in missing_entities:
             report_lines.append(f"- `[[{name}]]`")
         report_lines.append("")


### PR DESCRIPTION
## Summary

The lint report instructed users to run `python3 generate_missing_entities.py` which does not exist. Changed to the correct script `python3 tools/heal.py`.

Closes #53

## Changes

- `tools/lint.py` line 353: Updated the action hint from `generate_missing_entities.py` → `tools/heal.py`

One-line fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)