### PR TITLE
fix: replace broken star-history.com SVG with shields.io badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ NetworkX + Louvain + Claude + vis.js. No server, no database, runs entirely loca
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=SamurAIGPT/llm-wiki-agent&type=Date)](https://star-history.com/#SamurAIGPT/llm-wiki-agent&Date)
+[![Stars](https://img.shields.io/github/stars/SamurAIGPT/llm-wiki-agent?style=social)](https://github.com/SamurAIGPT/llm-wiki-agent/stargazers)
 
 ## License
 


### PR DESCRIPTION
## What

Replaces the broken `star-history.com` SVG in the README with a `shields.io` star badge.

## Why

The `api.star-history.com` SVG endpoint is timing out (`timeout of 10000ms exceeded`), which breaks the Star History chart for all visitors. This is a service-level outage affecting all repos, not specific to this project.

## Change

```diff
-[![Star History Chart](https://api.star-history.com/svg?repos=SamurAIGPT/llm-wiki-agent&type=Date)](https://star-history.com/#SamurAIGPT/llm-wiki-agent&Date)
+[![Stars](https://img.shields.io/github/stars/SamurAIGPT/llm-wiki-agent?style=social)](https://github.com/SamurAIGPT/llm-wiki-agent/stargazers)
```

- `img.shields.io` is a first-party GitHub badge service with high availability
- Badge shows star count with GitHub icon (social style)
- Clicking navigates to the stargazers page instead of a third-party site

Closes #58