### PR TITLE
feat: add GitHub Action for daily star history chart

### DIFF
--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -1,0 +1,35 @@
+name: Update Star History Chart
+
+on:
+  schedule:
+    - cron: '0 8 * * *'  # Daily at 08:00 UTC
+  workflow_dispatch:       # Allow manual trigger
+
+permissions:
+  contents: write
+
+jobs:
+  update-star-history:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Generate star history chart
+        uses: star-history/star-history-embed-image@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          repos: SamurAIGPT/llm-wiki-agent
+          type: Date
+
+      - name: Commit chart
+        run: |
+          if [ -f star-history-SamurAIGPT-llm-wiki-agent.svg ]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add star-history-SamurAIGPT-llm-wiki-agent.svg
+            git diff --cached --quiet || git commit -m "chore: update star history chart"
+            git push
+          else
+            echo "No chart generated, skipping commit"
+          fi

--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ NetworkX + Louvain + Claude + vis.js. No server, no database, runs entirely loca
 
 ## Star History
 
-[![Stars](https://img.shields.io/github/stars/SamurAIGPT/llm-wiki-agent?style=social)](https://github.com/SamurAIGPT/llm-wiki-agent/stargazers)
+[![Star History Chart](./star-history-SamurAIGPT-llm-wiki-agent.svg)](https://github.com/SamurAIGPT/llm-wiki-agent/stargazers)
 
 ## License
 


### PR DESCRIPTION
## What

Adds a GitHub Action that generates the star history chart daily and commits it as a static SVG file to the repo.

## Why

The `api.star-history.com` SVG endpoint is broken (GitHub restricted star data access). The current shields.io badge (#60) works but shows no history curve. This PR restores the line chart with zero external dependency at render time.

## How it works

```
GitHub Actions cron (daily 08:00 UTC)
  → star-history/star-history-embed-image action
  → generates SVG file in repo root
  → auto-commits if changed
```

README references the local SVG file, so the chart renders even if star-history.com goes down again.

## Files changed

- `.github/workflows/star-history.yml` — new workflow
- `README.md` — Star History section references local SVG

## Cost

Free — GitHub Actions is free for public repos.

Closes #58