### PR TITLE
feat: self-hosted star history chart via GitHub Action

### DIFF
--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -1,0 +1,35 @@
+name: Update Star History Chart
+
+on:
+  schedule:
+    - cron: '0 8 * * *'  # Daily at 08:00 UTC
+  workflow_dispatch:       # Allow manual trigger
+
+permissions:
+  contents: write
+
+jobs:
+  update-star-history:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Generate star history chart
+        uses: star-history/star-history-embed-image@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          repos: SamurAIGPT/llm-wiki-agent
+          type: Date
+
+      - name: Commit chart
+        run: |
+          if [ -f star-history-SamurAIGPT-llm-wiki-agent.svg ]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add star-history-SamurAIGPT-llm-wiki-agent.svg
+            git diff --cached --quiet || git commit -m "chore: update star history chart"
+            git push
+          else
+            echo "No chart generated, skipping commit"
+          fi

--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -1,35 +1,29 @@
-name: Update Star History Chart
+# Regenerates assets/star-history.svg weekly and commits it when it changes.
+name: Refresh Star History
 
 on:
   schedule:
-    - cron: '0 8 * * *'  # Daily at 08:00 UTC
-  workflow_dispatch:       # Allow manual trigger
+    - cron: '17 3 * * 1'   # every Monday 03:17 UTC
+  workflow_dispatch:        # allow manual runs
 
 permissions:
-  contents: write
+  contents: write           # needed to commit the refreshed chart
 
 jobs:
-  update-star-history:
+  refresh:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
-      - name: Generate star history chart
-        uses: star-history/star-history-embed-image@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Render star-history chart
+        uses: xingkongliang/star-history-svg@v1
         with:
-          repos: SamurAIGPT/llm-wiki-agent
-          type: Date
+          output: assets/star-history.svg
 
-      - name: Commit chart
+      - name: Commit if changed
         run: |
-          if [ -f star-history-SamurAIGPT-llm-wiki-agent.svg ]; then
-            git config user.name "github-actions[bot]"
-            git config user.email "github-actions[bot]@users.noreply.github.com"
-            git add star-history-SamurAIGPT-llm-wiki-agent.svg
-            git diff --cached --quiet || git commit -m "chore: update star history chart"
-            git push
-          else
-            echo "No chart generated, skipping commit"
-          fi
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add assets/star-history.svg
+          git diff --cached --quiet || git commit -m "chore: refresh star history"
+          git push

--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ NetworkX + Louvain + Claude + vis.js. No server, no database, runs entirely loca
 
 ## Star History
 
-[![Star History Chart](./star-history-SamurAIGPT-llm-wiki-agent.svg)](https://github.com/SamurAIGPT/llm-wiki-agent/stargazers)
+[![Star History Chart](assets/star-history.svg)](https://github.com/SamurAIGPT/llm-wiki-agent/stargazers)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ NetworkX + Louvain + Claude + vis.js. No server, no database, runs entirely loca
 
 ## Star History
 
-[![Stars](https://img.shields.io/github/stars/SamurAIGPT/llm-wiki-agent?style=social)](https://github.com/SamurAIGPT/llm-wiki-agent/stargazers)
+[![Star History Chart](./star-history-SamurAIGPT-llm-wiki-agent.svg)](https://github.com/SamurAIGPT/llm-wiki-agent/stargazers)
 
 ## License
 


### PR DESCRIPTION
## What

Replaces the broken star-history.com embed with a self-hosted star history chart generated by a GitHub Action.

## Why

Since 2026-06-30, GitHub restricts the stargazer timeline API to repo owners/collaborators. This broke:
- api.star-history.com SVG embeds (returns timeout / restricted access)
- star-history/star-history-embed-image action (repo no longer exists)

## Solution

Uses xingkongliang/star-history-svg — specifically built to work after the 2026 API restriction:

1. The workflow runs weekly (Monday 03:17 UTC) + manual trigger
2. Uses the repo's built-in GITHUB_TOKEN to read stargazer data
3. Renders a hand-drawn style SVG to assets/star-history.svg
4. Auto-commits only when the chart changes
5. README references the local SVG — zero external dependency at render time

## Files

- .github/workflows/star-history.yml — weekly auto-refresh workflow
- README.md — references assets/star-history.svg
- assets/ — chart output directory

## Cost

Free — GitHub Actions is free for public repos.

Closes #58
