### PR TITLE
fix: use correct star history action for 2026 API restriction

### DIFF
--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -1,35 +1,29 @@
-name: Update Star History Chart
+# Regenerates assets/star-history.svg weekly and commits it when it changes.
+name: Refresh Star History
 
 on:
   schedule:
-    - cron: '0 8 * * *'  # Daily at 08:00 UTC
-  workflow_dispatch:       # Allow manual trigger
+    - cron: '17 3 * * 1'   # every Monday 03:17 UTC
+  workflow_dispatch:        # allow manual runs
 
 permissions:
-  contents: write
+  contents: write           # needed to commit the refreshed chart
 
 jobs:
-  update-star-history:
+  refresh:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
-      - name: Generate star history chart
-        uses: star-history/star-history-embed-image@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Render star-history chart
+        uses: xingkongliang/star-history-svg@v1
         with:
-          repos: SamurAIGPT/llm-wiki-agent
-          type: Date
+          output: assets/star-history.svg
 
-      - name: Commit chart
+      - name: Commit if changed
         run: |
-          if [ -f star-history-SamurAIGPT-llm-wiki-agent.svg ]; then
-            git config user.name "github-actions[bot]"
-            git config user.email "github-actions[bot]@users.noreply.github.com"
-            git add star-history-SamurAIGPT-llm-wiki-agent.svg
-            git diff --cached --quiet || git commit -m "chore: update star history chart"
-            git push
-          else
-            echo "No chart generated, skipping commit"
-          fi
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add assets/star-history.svg
+          git diff --cached --quiet || git commit -m "chore: refresh star history"
+          git push

--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ NetworkX + Louvain + Claude + vis.js. No server, no database, runs entirely loca
 
 ## Star History
 
-[![Star History Chart](./star-history-SamurAIGPT-llm-wiki-agent.svg)](https://github.com/SamurAIGPT/llm-wiki-agent/stargazers)
+[![Star History Chart](assets/star-history.svg)](https://github.com/SamurAIGPT/llm-wiki-agent/stargazers)
 
 ## License
 


### PR DESCRIPTION
## What

Fixes the star history GitHub Action to use the correct action that works with GitHub's 2026 stargazer API restriction.

## Context

PR #62 added the initial workflow using star-history/star-history-embed-image, but that action no longer exists. This PR switches to xingkongliang/star-history-svg which is specifically designed for the 2026 API restriction.

## Change

- Action: star-history/star-history-embed-image -> xingkongliang/star-history-svg@v1
- Output path: star-history-SamurAIGPT-llm-wiki-agent.svg -> assets/star-history.svg
- Schedule: daily -> weekly (Monday 03:17 UTC)
- README: references assets/star-history.svg

## How it works

The action uses the repo's built-in GITHUB_TOKEN to read stargazer data (which works because the token belongs to the repo owner), renders a hand-drawn style SVG, and auto-commits it. Readers just load the local image — zero external dependency.

Closes #58
