### PR TITLE
fix: create assets/ dir before star history render

### DIFF
--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -15,6 +15,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Ensure assets directory exists
+        run: mkdir -p assets
+
       - name: Render star-history chart
         uses: xingkongliang/star-history-svg@v1
         with:


### PR DESCRIPTION
## What

Adds mkdir -p assets before the star history render step.

## Why

The workflow failed with FileNotFoundError because assets/ directory doesn't exist in the repo yet. The xingkongliang/star-history-svg action doesn't create output directories automatically.

## Change

One line added to the workflow: mkdir -p assets

See: https://github.com/SamurAIGPT/llm-wiki-agent/actions/runs/29073352615
