### PR TITLE
fix: thin x-axis month labels to prevent overlap

### DIFF
--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -20,6 +20,18 @@ jobs:
         with:
           output: assets/star-history.svg
 
+      - name: Thin x-axis labels (keep every other month)
+        run: |
+          python3 << 'PYEOF'
+          import re
+          svg = open("assets/star-history.svg").read()
+          labels = list(re.finditer(r'<text [^>]*y="394\.0"[^>]*>.*?</text>\n?', svg))
+          # remove odd-indexed labels (keep 1st, 3rd, 5th ...)
+          for m in reversed(labels[1::2]):
+              svg = svg[:m.start()] + svg[m.end():]
+          open("assets/star-history.svg", "w").write(svg)
+          PYEOF
+
       - name: Commit if changed
         run: |
           git config user.name  "github-actions[bot]"


### PR DESCRIPTION
## What

Adds a post-processing step to the star history workflow that removes every other month label from the x-axis.

## Why

The SVG chart shows every month, causing labels to crowd together when the repo has a long star history. With 26+ months of data in 800px wide SVG, labels are only ~26px apart.

## Change

After the chart is rendered, a Python script removes odd-indexed month labels (keeps 1st, 3rd, 5th...), doubling the spacing between visible labels.
