### PR TITLE
fix: use PAT for star-history stargazer API

### DIFF
--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -22,6 +22,7 @@ jobs:
         uses: xingkongliang/star-history-svg@v1
         with:
           output: assets/star-history.svg
+          token: ${{ secrets.STAR_HISTORY_TOKEN }}
 
       - name: Thin x-axis labels (yearly only)
         env:


### PR DESCRIPTION
## Summary
- GitHub restricted the stargazer timeline API to repo owner/collaborator tokens since 2026-06-30
- The default `GITHUB_TOKEN` in Actions no longer has access, causing 403 failures
- Pass a collaborator PAT via `STAR_HISTORY_TOKEN` secret to restore the workflow

## Test plan
- [ ] Merge this PR
- [ ] Trigger workflow manually (`workflow_dispatch`) to verify the chart renders successfully
- [ ] Confirm next scheduled run (Monday 03:17 UTC) passes